### PR TITLE
Fixed FLAP's CMakeLists

### DIFF
--- a/CMake/FLAPConfig.cmake.in
+++ b/CMake/FLAPConfig.cmake.in
@@ -1,59 +1,7 @@
-#################################################################
-# @PROJECT_NAME@ Config file
-#################################################################
+include(CMakeFindDependencyMacro)
+find_dependency(PENF REQUIRED)
+find_dependency(FACE REQUIRED)
 
-SET(TARGET_NAME @PROJECT_NAME@)
-
-#################################################################
-# PATHS
-#################################################################
-
-SET(${TARGET_NAME}_DIR          @PROJECT_BINARY_DIR@)
-SET(${TARGET_NAME}_BINARY_DIRS  @EXECUTABLE_OUTPUT_PATH@)
-SET(${TARGET_NAME}_LIBRARY_DIRS @LIBRARY_OUTPUT_PATH@)
-SET(${TARGET_NAME}_INCLUDE_DIRS @MODULE_OUTPUT_PATH@)
-
-#################################################################
-# TARGETS
-#################################################################
-
-SET(${TARGET_NAME}_INC_SUFFIXES "include" "cmake" "${TARGET_NAME}" "include/${TARGET_NAME}" "cmake/${TARGET_NAME}")
-
-SET(${LIB_PREFIX}_FOUND FALSE)
-
-FIND_FILE(${TARGET_NAME}_TARGET
-    NAMES ${TARGET_NAME}Targets.cmake
-    PATHS ${${TARGET_NAME}_DIR}  ENV PATH LD_LIBRARY_PATH
-    PATH_SUFFIXES ${${TARGET_NAME}_INC_SUFFIXES}
-    DOC "The path to ${TARGET_NAME} library"
-)
-
-IF(${TARGET_NAME}_TARGET)
-    INCLUDE(${${TARGET_NAME}_TARGET})
-
-    SET(${TARGET_NAME}_FOUND TRUE)
-
-    GET_PROPERTY(${TARGET_NAME}_BUILD_TYPE 
-                 TARGET ${TARGET_NAME} 
-                 PROPERTY IMPORTED_CONFIGURATIONS)
-
-    GET_PROPERTY(${TARGET_NAME}_LINK_LIBS 
-                 TARGET ${TARGET_NAME} 
-                 PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES_${${TARGET_NAME}_BUILD_TYPE})
-
-    GET_PROPERTY(${TARGET_NAME}_LIB 
-                 TARGET ${TARGET_NAME} 
-                 PROPERTY IMPORTED_LOCATION_${${TARGET_NAME}_BUILD_TYPE})
-
-    SET(${TARGET_NAME}_LIBS 
-                 ${${TARGET_NAME}_LINK_LIBS} ${${TARGET_NAME}_LIB} 
-                 CACHE STRING "${TARGET_NAME} libraries to link")
-
-    SET(${TARGET_NAME}_INCLUDES 
-                 ${${TARGET_NAME}_INCLUDE_DIRS} 
-                 CACHE STRING "Directories containing ${TARGET_NAME} modules")
-ELSE()
-    MESSAGE(FATAL_ERROR "Cannot find ${TARGET_NAME} TARGET description. ${TARGET_NAME}_DIR must contain a path where to find ${TARGET_NAME} already builded!")
-ENDIF()
-
-UNSET(${TARGET_NAME}_TARGET CACHE)
+if(NOT TARGET FLAP::FLAP)
+    include("${CMAKE_CURRENT_LIST_DIR}/FLAPTargets.cmake")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,10 @@
 #################################################################
 # HEADER
 #################################################################
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8.7)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.11)
 SET(CMAKE_ALLOW_LOOSE_LOOP_CONSTRUCTS TRUE)
+
+CMAKE_POLICY(SET CMP0022 NEW)
 
 PROJECT(FLAP Fortran)
 
@@ -10,38 +12,9 @@ SET(${PROJECT_NAME}_VERSION 0.0.1)
 SET(${PROJECT_NAME}_SOVERSION 1)
 SET(LIB ${PROJECT_NAME})
 
-SET(CMAKE_VERBOSE_MAKEFILE TRUE)
 SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
-#################################################################
-# DEFINE PATHS
-#################################################################
-
-SET(CMAKE_PATH ${CMAKE_SOURCE_DIR}/CMake)
-SET(SRC_PATH ${CMAKE_SOURCE_DIR}/src)
-SET(LIB_PATH ${SRC_PATH}/lib)
-SET(TESTS_PATH ${SRC_PATH}/tests)
-SET(THIRDPARTY_PATH ${SRC_PATH}/third_party)
-
-#SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/CMake/Modules/")
-
-
-#################################################################
-# BUILD PATHS
-#################################################################
-
-SET(LIBRARY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/lib)
-SET(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
-SET(CMAKE_Fortran_MODULE_DIRECTORY ${PROJECT_BINARY_DIR}/modules)
-SET(MODULE_OUTPUT_PATH ${CMAKE_Fortran_MODULE_DIRECTORY})
-SET(THIRDPARTY_OUTPUT_PATH ${PROJECT_BINARY_DIR}/third_party)
-INCLUDE_DIRECTORIES(${CMAKE_Fortran_MODULE_DIRECTORY})
-
-#################################################################
-# ADD INCLUDE DIRS
-#################################################################
-
-SET(${PROJECT_NAME}_INCLUDE_DIRS ${MODULE_OUTPUT_PATH})
+SET(FLAP_CONFIG_MODULE ${CMAKE_CURRENT_LIST_DIR}/CMake/FLAPConfig.cmake.in)
 
 #################################################################
 # CONFIGURATION TYPES & BUILD MODE
@@ -136,69 +109,55 @@ ENDIF()
 #################################################################
 
 include(ExternalProject)
-SET(PENF_LIB PENF)
 
-SET(${PENF_LIB}_SRC_PATH ${THIRDPARTY_PATH}/PENF)
-MESSAGE(STATUS "${PENF_LIB}_SRC_PATH: ${${PENF_LIB}_SRC_PATH}")
-SET(${PENF_LIB}_BINARY_PATH ${THIRDPARTY_OUTPUT_PATH}/${PENF_LIB})
-EXTERNALPROJECT_Add(${PENF_LIB}
-    DOWNLOAD_COMMAND ""
-    SOURCE_DIR ${${PENF_LIB}_SRC_PATH}
-    BINARY_DIR ${${PENF_LIB}_BINARY_PATH}
-    INSTALL_DIR ${INSTALL_PREFIX}
-    # Fortran compiler must be forced in order to link external projects from the main project
-    CONFIGURE_COMMAND cmake -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER} ${${PENF_LIB}_SRC_PATH}
-    BUILD_COMMAND cmake --build .
-    TEST_COMMAND ""
-    INSTALL_COMMAND ""
+EXTERNALPROJECT_Add(PENF
+  PREFIX      ${CMAKE_CURRENT_BINARY_DIR}/PENF
+  SOURCE_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/PENF
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+
+  CMAKE_ARGS
+    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} 
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
 )
+SET(PENF_LIBRARY ${CMAKE_INSTALL_PREFIX}/lib/libPENF.a)
+SET(PENF_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include/PENF)
 
-# The order of the libraries reveals the right linking order
-SET(PENF_LIBS ${${PENF_LIB}_BINARY_PATH}/lib/lib${PENF_LIB}.a)
-LINK_DIRECTORIES(${THIRDPARTY_OUTPUT_PATH}/${PENF_LIB}/lib)
-INCLUDE_DIRECTORIES(${THIRDPARTY_OUTPUT_PATH}/${PENF_LIB}/modules)
-SET(${PROJECT_NAME}_INCLUDE_DIRS ${${PROJECT_NAME}_INCLUDE_DIRS} ${THIRDPARTY_OUTPUT_PATH}/${PENF_LIB}/modules)
 
-# FACE #
-include(ExternalProject)
-SET(FACE_LIB FACE)
+EXTERNALPROJECT_Add(FACE
+  PREFIX      ${CMAKE_CURRENT_BINARY_DIR}/FACE
+  SOURCE_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/FACE
+  INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
 
-SET(${FACE_LIB}_SRC_PATH ${THIRDPARTY_PATH}/FACE)
-MESSAGE(STATUS "${FACE_LIB}_SRC_PATH: ${${FACE_LIB}_SRC_PATH}")
-SET(${FACE_LIB}_BINARY_PATH ${THIRDPARTY_OUTPUT_PATH}/${FACE_LIB})
-EXTERNALPROJECT_Add(${FACE_LIB}
-    DOWNLOAD_COMMAND ""
-    SOURCE_DIR ${${FACE_LIB}_SRC_PATH}
-    BINARY_DIR ${${FACE_LIB}_BINARY_PATH}
-    INSTALL_DIR ${INSTALL_PREFIX}
-    # Fortran compiler must be forced in order to link external projects from the main project
-    CONFIGURE_COMMAND cmake -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER} ${${FACE_LIB}_SRC_PATH}
-    BUILD_COMMAND cmake --build .
-    TEST_COMMAND ""
-    INSTALL_COMMAND ""
+  CMAKE_ARGS
+    -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} 
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+    -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+    -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
 )
-
-# The order of the libraries reveals the right linking order
-SET(FACE_LIBS ${${FACE_LIB}_BINARY_PATH}/lib/lib${FACE_LIB}.a)
-LINK_DIRECTORIES(${THIRDPARTY_OUTPUT_PATH}/${FACE_LIB}/lib)
-INCLUDE_DIRECTORIES(${THIRDPARTY_OUTPUT_PATH}/${FACE_LIB}/modules)
-SET(${PROJECT_NAME}_INCLUDE_DIRS ${${PROJECT_NAME}_INCLUDE_DIRS} ${THIRDPARTY_OUTPUT_PATH}/${FACE_LIB}/modules)
+SET(FACE_LIBRARY ${CMAKE_INSTALL_PREFIX}/lib/libFACE.a)
+SET(FACE_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include/FACE)
 
 #################################################################
 # ADD SOURCE SUBDIRS
 #################################################################
 
-ADD_SUBDIRECTORY(${LIB_PATH})
+ADD_SUBDIRECTORY(src/lib)
 IF(${PROJECT_NAME}_ENABLE_TESTS)
-    ADD_SUBDIRECTORY(${THIRDPARTY_PATH}/fortran_tester)
-    ADD_SUBDIRECTORY(${TESTS_PATH})
+    EXTERNALPROJECT_Add(fortran_tester
+      PREFIX      ${CMAKE_CURRENT_BINARY_DIR}/fortran_tester
+      SOURCE_DIR  ${CMAKE_CURRENT_SOURCE_DIR}/src/third_party/fortran_tester
+      INSTALL_DIR ${CMAKE_INSTALL_PREFIX}
+
+      CMAKE_ARGS
+        -DBUILD_SHARED_LIBS=${BUILD_SHARED_LIBS} 
+        -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+        -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+        -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE}
+    )
+    SET(fortran_tester_LIBRARY ${CMAKE_INSTALL_PREFIX}/lib/libfortran_tester.a)
+    SET(fortran_tester_INCLUDE_DIR ${CMAKE_INSTALL_PREFIX}/include/fortran_tester)
+
+    ADD_SUBDIRECTORY(src/tests)
 ENDIF()
-
-#################################################################
-# CREATE CONFIG FILE
-#################################################################
-
-CONFIGURE_FILE(${CMAKE_PATH}/${PROJECT_NAME}Config.cmake.in 
-               ${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake
-               @ONLY)
-

--- a/src/lib/CMakeLists.txt
+++ b/src/lib/CMakeLists.txt
@@ -8,14 +8,62 @@ SET(LIB_SRC ${LIB_SRC} PARENT_SCOPE)
 #################################################################
 # Library target
 #################################################################
-ADD_LIBRARY(${LIB} ${LIB_SRC})
+ADD_LIBRARY(FLAP 
+        flap_command_line_arguments_group_t.f90
+        flap_command_line_argument_t.F90
+        flap_command_line_interface_t.F90
+        flap.f90
+        flap_object_t.f90
+        flap_utils_m.f90
+)
+SET_TARGET_PROPERTIES(FLAP PROPERTIES 
+        Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules
+)
 
-#################################################################
-# External projects
-#################################################################
-FOREACH(PENF_LIB ${PENF_LIBS} ${FACE_LIBS})
-        TARGET_LINK_LIBRARIES(${LIB} ${PENF_LIB})
-ENDFOREACH()
+TARGET_LINK_LIBRARIES(FLAP 
+        PUBLIC
+                $<BUILD_INTERFACE:${FACE_LIBRARY}>
+                $<BUILD_INTERFACE:${PENF_LIBRARY}>
+                $<INSTALL_INTERFACE:FACE::FACE>
+                $<INSTALL_INTERFACE:PENF::PENF>
+)
+IF(CMAKE_BUILD_TYPE MATCHES "DEBUG")
+        TARGET_LINK_LIBRARIES(FLAP INTERFACE -lgcov)
+ENDIF()
+TARGET_INCLUDE_DIRECTORIES(FLAP 
+        PUBLIC
+                $<BUILD_INTERFACE:${FACE_INCLUDE_DIR}>
+                $<BUILD_INTERFACE:${PENF_INCLUDE_DIR}>
+        INTERFACE
+                $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/modules>
+                $<INSTALL_INTERFACE:include/FLAP>
+)
+ADD_DEPENDENCIES(FLAP PENF FACE)
 
-SET_TARGET_PROPERTIES(${LIB} PROPERTIES VERSION ${${LIB}_VERSION} SOVERSION ${${LIB}_SOVERSION})
-EXPORT(TARGETS ${LIB} APPEND FILE ${PROJECT_BINARY_DIR}/${LIB}Targets.cmake)
+INCLUDE(GNUInstallDirs)
+INSTALL(TARGETS FLAP
+        EXPORT FLAP-export
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)
+INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules/ DESTINATION include/FLAP)
+INSTALL(EXPORT FLAP-export
+        FILE
+                FLAPTargets.cmake
+        NAMESPACE
+                FLAP::
+        DESTINATION
+                ${CMAKE_INSTALL_LIBDIR}/cmake/FLAP
+)
+INCLUDE(CMakePackageConfigHelpers)
+configure_package_config_file(${PROJECT_SOURCE_DIR}/CMake/FLAPConfig.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/FLAPConfig.cmake
+        INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/FLAP
+)
+
+INSTALL(FILES 
+        ${CMAKE_CURRENT_BINARY_DIR}/FLAPConfig.cmake 
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/FLAP
+)
+EXPORT(EXPORT FLAP-export FILE ${CMAKE_CURRENT_BINARY_DIR}/FLAPConfig.cmake NAMESPACE FLAP::)
+EXPORT(PACKAGE FLAP)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -12,15 +12,9 @@ SET(TESTS_SRC ${TESTS_SRC} PARENT_SCOPE)
 FOREACH(TEST_SRC ${TESTS_SRC})
     GET_FILENAME_COMPONENT(EXE_NAME ${TEST_SRC} NAME_WE)
     ADD_EXECUTABLE(${EXE_NAME} ${TEST_SRC})
-    TARGET_LINK_LIBRARIES(${EXE_NAME} ${LIB} fortran_tester)
-
-    #################################################################
-    # External projects
-    #################################################################
-    FOREACH(PENF_LIB ${PENF_LIBS})
-            TARGET_LINK_LIBRARIES(${EXE_NAME} ${PENF_LIB})
-    ENDFOREACH()
-
+    TARGET_LINK_LIBRARIES(${EXE_NAME} PRIVATE ${LIB} ${fortran_tester_LIBRARY} FLAP)
+    TARGET_INCLUDE_DIRECTORIES(${EXE_NAME} PRIVATE ${fortran_tester_INCLUDE_DIR})
+    ADD_DEPENDENCIES(${EXE_NAME} fortran_tester)
     ADD_TEST(${EXE_NAME}_TEST ${EXECUTABLE_OUTPUT_PATH}/${EXE_NAME})
 ENDFOREACH()
 


### PR DESCRIPTION
Targets should be getting exported properly now. Installation should be
correct now too. When you do find_package(FLAP), FACE and PENF are found
as well.

I also pass `CMAKE_POSITION_INDEPENDENT_CODE` to the ExternalProjects so FACE and PENF are built with position independent code if FLAP is.